### PR TITLE
scrape custom records even if show inactives is checked

### DIFF
--- a/lib/loader/load-records.js
+++ b/lib/loader/load-records.js
@@ -22,8 +22,8 @@ module.exports = function(casper, init) {
 
             for (var r = 0; r < rows.length; r++) {
                 var row = $(rows[r]),
-                    recType = row.find('td:nth-child(3)').text().trim(),
-                    recId = Number(row.find('td:nth-child(1) a').attr('href').match(/[0-9]+/g)[0]);
+                    recType = row.find('td').filter('.listtext').filter(':eq(2)').text().trim(),
+                    recId = Number(row.find('td').filter('.listtext').filter(':eq(0)').find('a').attr('href').match(/[0-9]+/g)[0]);
 
                 $RecordTypes[recType] = recId;
                 $RecordIds[recId] = recType;


### PR DESCRIPTION
Checking the "Show Inactives" box on custom records adds a column to the table, and this table contains a checkbox input. 

The class listtextctr is applied to the added column and so, these selector changes will filter that out, and proceed with the scrape as normal.

Not completely elegant, but functional.
